### PR TITLE
chore: add config to fix dependabot PRs

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,15 @@
+const Configuration = {
+  /*
+   * Resolve and load @commitlint/config-conventional from node_modules.
+   * Referenced packages must be installed
+   */
+  extends: ['@commitlint/config-conventional'],
+  /*
+   * Any rules defined here will override rules from @commitlint/config-conventional
+   */
+  rules: {
+    'body-max-line-length': [1, 'always', 80],
+  },
+};
+
+module.exports = Configuration;


### PR DESCRIPTION
This configuration overrides the default commitlint action config to set
the "commit body line length" check from an error to a warning.

<!--
IMPORTANT NOTE: Commits must adhere to the conventional commits specification:
https://www.conventionalcommits.org/en/v1.0.0/

Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
