### PR TITLE
chore: bump go.mod go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smlx/ccv
 
-go 1.21
+go 1.22.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
Since 1.21.0 version number needs three parts.
