### PR TITLE
fix: git security workaround

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 set -eu
 # if the first argument to the script is "true", it will push a tag to the repository.
 WRITE_TAG="$1"
+# the runner workspace will be mounted here, and git complains otherwise
+git config --global --add safe.directory /github/workspace
 # if the ccv tag exists, just exit
 if [ "$(git tag -l "$(ccv)")" ]; then
 	echo "new_tag=false" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
This fixes a security check in recent git versions:

  fatal: detected dubious ownership in repository at '/github/workspace'
