### PR TITLE
Add optional version type output

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,12 +31,14 @@ jobs:
       with:
         fetch-depth: 0
     - id: ccv
-      uses: smlx/ccv@d3de774e9b607b079940a7a86952f44643743336 # v0.9.0
+      uses: smlx/ccv@f1246290d5eba91141b7a3ae9820051449292314 # v0.9.0-23-gf124629
       with:
         write-tag: false
     - run: |
         echo "new-tag=$NEW_TAG"
         echo "new-tag-version=$NEW_TAG_VERSION"
+        echo "new-tag-version-type=$NEW_TAG_VERSION_TYPE"
       env:
         NEW_TAG: ${{steps.ccv.outputs.new-tag}}
         NEW_TAG_VERSION: ${{steps.ccv.outputs.new-tag-version}}
+        NEW_TAG_VERSION_TYPE: ${{steps.ccv.outputs.new-tag-version-type}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM alpine:3.20
-RUN apk --no-cache add curl git jq \
-    && (if echo "$TARGETPLATFORM" | grep -q arm; then \
-    curl -sSL $(curl -s https://api.github.com/repos/smlx/ccv/releases/latest | jq -r '.assets[].browser_download_url | select(test("linux_arm64"))'); \
-    else \
-    curl -sSL $(curl -s https://api.github.com/repos/smlx/ccv/releases/latest | jq -r '.assets[].browser_download_url | select(test("linux_amd64"))'); \
-    fi) \
-    | tar -xz -C /usr/local/bin ccv
+FROM alpine:3.20@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d AS builder
+COPY . .
+RUN apk --no-cache add go && CGO_ENABLED=0 go build ./cmd/ccv
+FROM alpine:3.20@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
+RUN apk --no-cache add git
+COPY --from=builder ccv /usr/local/bin/
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ mod-tidy:
 
 .PHONY: build
 build:
-	GOVERSION=$$(go version) \
-						goreleaser build --clean --debug --single-target --snapshot
+	goreleaser build --clean --debug --single-target --snapshot
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Outputs:
 
 * `new-tag`: Either "true" or "false" depending on whether a new tag was pushed. Example: `true`.
 * `new-tag-version`: The new version that was tagged. This will only be set if new_tag=true. Example: `v0.1.2`.
+* `new-tag-version-type`: The new version type (major, minor, patch) was tagged. This will only be set if new_tag=true. Example: `minor`.
 
 ### Example: automatic tagging
 
@@ -92,9 +93,11 @@ jobs:
     - run: |
         echo "new-tag=$NEW_TAG"
         echo "new-tag-version=$NEW_TAG_VERSION"
+        echo "new-tag-version-type=$NEW_TAG_VERSION_TYPE"
       env:
         NEW_TAG: ${{steps.ccv.outputs.new-tag}}
         NEW_TAG_VERSION: ${{steps.ccv.outputs.new-tag-version}}
+        NEW_TAG_VERSION_TYPE: ${{steps.ccv.outputs.new-tag-version-type}}
 ```
 
 Gives this output:
@@ -102,6 +105,7 @@ Gives this output:
 ```
 new-tag=true
 new-tag-version=v0.16.0
+new-tag-version-type=minor
 ```
 
 For a fully-functional example, see the [build workflow of this repository](https://github.com/smlx/ccv/blob/main/.github/workflows/build.yaml).

--- a/action.yaml
+++ b/action.yaml
@@ -9,7 +9,9 @@ outputs:
   new-tag:
     description: Either "true" or "false" depending on whether a new tag was pushed.
   new-tag-version:
-    description: The new version that was tagged. This will only be set if new_tag=true.
+    description: The new version that was tagged. This will only be set if new-tag=true.
+  new-tag-version-type:
+    description: Describes the semantic version type of the new tag. One of "major", "minor", or "patch". This will only be set if new-tag=true.
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,5 +14,8 @@ if [ "$WRITE_TAG" = "true" ]; then
 	git tag "$(ccv)"
 	git push --tags
 fi
-echo "new-tag=true" >>"$GITHUB_OUTPUT"
-echo "new-tag-version=$(ccv)" >>"$GITHUB_OUTPUT"
+{
+	echo "new-tag=true"
+	echo "new-tag-version=$(ccv)"
+	echo "new-tag-version-type=$(ccv --version-type)"
+} >>"$GITHUB_OUTPUT"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
+	github.com/alecthomas/kong v1.5.1
 	github.com/go-git/go-git/v5 v5.12.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,12 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
+github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
+github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/kong v1.5.1 h1:9quB93P2aNGXf5C1kWNei85vjBgITNJQA4dSwJQGCOY=
+github.com/alecthomas/kong v1.5.1/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
+github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
+github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -38,6 +44,8 @@ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=


### PR DESCRIPTION
Add version bump type (major, minor, patch) as optional output for the ccv CLI and the ccv action.

Hopefully closes #161 